### PR TITLE
Recognize C++17 usage in parent projects

### DIFF
--- a/SortFilterProxyModel.pri
+++ b/SortFilterProxyModel.pri
@@ -1,4 +1,4 @@
-!contains( CONFIG, c\+\+1[14] ): warning("SortFilterProxyModel needs at least c++11, add CONFIG += c++11 to your .pro")
+!contains( CONFIG, c\+\+1[147] ): warning("SortFilterProxyModel needs at least c++11, add CONFIG += c++11 to your .pro")
 
 INCLUDEPATH += $$PWD
 


### PR DESCRIPTION
Avoids printing an error message that C++11 is required, if C++17 is
already being used.