### PR TITLE
Remove unused lambda capture

### DIFF
--- a/qqmlsortfilterproxymodel.cpp
+++ b/qqmlsortfilterproxymodel.cpp
@@ -339,7 +339,7 @@ bool QQmlSortFilterProxyModel::filterAcceptsRow(int source_row, const QModelInde
     bool valueAccepted = !m_filterValue.isValid() || ( m_filterValue == sourceModel()->data(sourceIndex, filterRole()) );
     bool baseAcceptsRow = valueAccepted && QSortFilterProxyModel::filterAcceptsRow(source_row, source_parent);
     baseAcceptsRow = baseAcceptsRow && std::all_of(m_filters.begin(), m_filters.end(),
-        [=, &source_parent] (Filter* filter) {
+        [=] (Filter* filter) {
             return filter->filterAcceptsRow(sourceIndex, *this);
         }
     );


### PR DESCRIPTION
This fixes an error ' error: lambda capture 'source_parent' is not used
[-Werror,-Wunused-lambda-capture]' produced by clang with -Wall -Wextra
-pedantic -Wno-deprecated-declarations -Wno-deprecated-copy -Werror